### PR TITLE
Instantiate Sylvie Starting Position (Visual Glitch)

### DIFF
--- a/Assets/Scenes/Arshiya/TestGemini.unity
+++ b/Assets/Scenes/Arshiya/TestGemini.unity
@@ -2976,6 +2976,41 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2186617730035520622, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
   m_PrefabInstance: {fileID: 833151317}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &837064670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 837064671}
+  m_Layer: 5
+  m_Name: start
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &837064671
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 837064670}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8257051831353604193}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!4 &847935754 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3599861841851639352, guid: c29f1d8a49acf3f4198a10385d774474, type: 3}
@@ -5939,11 +5974,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8835112654290279075, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -148.20006
+      value: -140
       objectReference: {fileID: 0}
     - target: {fileID: 8835112654290279075, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -56.6
+      value: -44
       objectReference: {fileID: 0}
     - target: {fileID: 8835112654290279075, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5984,6 +6019,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 3289613599486868265, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1806394503}
+    - targetCorrespondingSourceObject: {fileID: 3289613599486868265, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1806394516}
   m_SourcePrefab: {fileID: 100100000, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
 --- !u!1 &1806394502 stripped
 GameObject:
@@ -6016,6 +6054,20 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8835112654290279075, guid: 8aa31d23db44abf4d8a45e70050abf8d, type: 3}
   m_PrefabInstance: {fileID: 1806394501}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1806394516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1806394502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ea6fb3fdb38285488e89cd539063c62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startingPos: {fileID: 837064670}
+  syvlie: {fileID: 1806394502}
 --- !u!1 &1863141091 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4212196375729579896, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
@@ -7621,7 +7673,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2186617730035520622, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 837064671}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
 --- !u!224 &8257051831353604193 stripped

--- a/Assets/Scenes/Arshiya/TestGemini.unity
+++ b/Assets/Scenes/Arshiya/TestGemini.unity
@@ -680,6 +680,139 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &201970802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 201970803}
+  - component: {fileID: 201970806}
+  - component: {fileID: 201970805}
+  - component: {fileID: 201970804}
+  m_Layer: 5
+  m_Name: undo button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &201970803
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201970802}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 519963860}
+  m_Father: {fileID: 754152118}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -757, y: -438}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &201970804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201970802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 201970805}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 754152122}
+        m_TargetAssemblyTypeName: GeminiManager, Assembly-CSharp
+        m_MethodName: undo
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &201970805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201970802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &201970806
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201970802}
+  m_CullTransparentMesh: 1
 --- !u!1 &206536732 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4212196375729579896, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
@@ -2015,6 +2148,140 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &519963859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 519963860}
+  - component: {fileID: 519963862}
+  - component: {fileID: 519963861}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &519963860
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519963859}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 201970803}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &519963861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519963859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: UNDO
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &519963862
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519963859}
+  m_CullTransparentMesh: 1
 --- !u!1 &539857250 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4212196375729579896, guid: a1f43b26b0abf1a40b64e5aa956ead45, type: 3}
@@ -2570,6 +2837,7 @@ RectTransform:
   - {fileID: 156091918}
   - {fileID: 1143370115}
   - {fileID: 1806394509}
+  - {fileID: 201970803}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Scripts/Level Control Systems/GeminiManager.cs
+++ b/Assets/Scripts/Level Control Systems/GeminiManager.cs
@@ -43,23 +43,27 @@ public class GeminiManager : MonoBehaviour
         pollusPos = pollus.GetComponent<Transform>();
         sylviePos = sylvie.GetComponent<Transform>();
 
+        Debug.Log("hello");
         //add every star to the array
         for (int i = 0; i < constellationController.transform.childCount; i++) {
             int childCount = 0;
             for (int j = 0; j < 7; j++) {
                 //extra childCount variable to account for gaps
                 if (childCount >= constellationController.transform.GetChild(i).childCount) {
+                    Debug.Log("broke");
                     break;
                 }
                 //add the child to the array
                 int curY = int.Parse(constellationController.transform.GetChild(i).GetChild(childCount).name.Substring(3,1));
                 constellationArr[i,curY] = constellationController.transform.GetChild(i).GetChild(childCount);
                 childCount++;
+                Debug.Log("child");
                 //button disabling
                 if (!((i == curSylvieR && (curY == curSylvieC - 1 ||curY == curSylvieC + 1))
                     || (curY == curSylvieC && (i == curSylvieR - 1 ||i == curSylvieR + 1)))) {
                     constellationArr[i,curY].gameObject.GetComponent<Button>().interactable = false ;
-                } 
+                    Debug.Log("disable");
+                }
             }
         }
         

--- a/Assets/Scripts/Level Control Systems/GeminiManager.cs
+++ b/Assets/Scripts/Level Control Systems/GeminiManager.cs
@@ -13,6 +13,12 @@ public class GeminiManager : MonoBehaviour
     private static int curCastorC;
     private static int curSylvieC;
     private static int curSylvieR;
+    private static int prevPollusR;
+    private static int prevPollusC;
+    private static int prevCastorR;
+    private static int prevCastorC;
+    private static int prevSylvieR;
+    private static int prevSylvieC;
     private static int targetPositionr1;
     private static int targetPositionr2;
     private static int targetPositionc1;
@@ -100,15 +106,25 @@ public class GeminiManager : MonoBehaviour
             pollusC++;
         } 
 
-        //syvlie/NPC overlap ?
-        if ((sylvieC == curCastorC && sylvieR == curCastorR) || (sylvieC == curPollusC && sylvieR == curPollusR)) {
-            //bounce animation?
+        if ((sylvieC == curPollusC && sylvieR == curPollusR) || (sylvieC == pollusC && sylvieR == pollusR)) {
             return;
         }
-        if ((sylvieC == castorC && sylvieR == castorR) || (sylvieC == pollusC && sylvieR == pollusR)) {
-            //bounce animation?
-            return;
+        if (sylvieR == curCastorR && sylvieC == curCastorC) {
+            if (castorR >= 7 || castorR < 0 || castorC >= 7 || castorC < 0) {
+                return;
+            } else if (constellationArr[castorR, castorC] == null) {
+                return;
+            }
         }
+        // //syvlie/NPC overlap ?
+        // if ((sylvieC == curCastorC && sylvieR == curCastorR) || (sylvieC == curPollusC && sylvieR == curPollusR)) {
+        //     //bounce animation?
+        //     return;
+        // }
+        // if ((sylvieC == castorC && sylvieR == castorR) || (sylvieC == pollusC && sylvieR == pollusR)) {
+        //     //bounce animation?
+        //     return;
+        // }
 
         //update sylvie's position
         sylviePos.position = new Vector3(constellationArr[sylvieR,sylvieC].position.x, constellationArr[sylvieR,sylvieC].position.y,0);
@@ -141,6 +157,8 @@ public class GeminiManager : MonoBehaviour
             constellationArr[curSylvieR - 1,curSylvieC].gameObject.GetComponent<Button>().interactable = false ;
         }
         //update the saved position
+        prevSylvieR = curSylvieR;
+        prevSylvieC = curSylvieC;
         curSylvieR = sylvieR;
         curSylvieC = sylvieC;
         
@@ -157,6 +175,8 @@ public class GeminiManager : MonoBehaviour
         //update Pollus' position
         if (pollusR < 7 && pollusR >= 0 && pollusC < 7 && pollusC >= 0 && constellationArr[pollusR,pollusC] != null) {
             pollusPos.position = new Vector3(constellationArr[pollusR,pollusC].position.x, constellationArr[pollusR,pollusC].position.y,0) ;
+            prevPollusR = curPollusR;
+            prevPollusC = curPollusC;
             curPollusR = pollusR;
             curPollusC = pollusC;
         }
@@ -164,11 +184,72 @@ public class GeminiManager : MonoBehaviour
         //update Castor's position
         if (castorR < 7 && castorR >= 0 && castorC < 7 && castorC >= 0 && constellationArr[castorR, castorC] != null) {
             castorPos.position = new Vector3(constellationArr[castorR,castorC].position.x, constellationArr[castorR,castorC].position.y,0) ;
+            prevCastorR = curCastorR;
+            prevCastorC = curCastorC;
             curCastorR = castorR;
             curCastorC = castorC;
         }
+        
     }
 
+    public static void undo() {
+        if (prevSylvieR == -1) {
+            return;
+        }
+        if (prevSylvieC + 1 < 7 && constellationArr[prevSylvieR, prevSylvieC + 1] != null) {
+            constellationArr[prevSylvieR,prevSylvieC + 1].gameObject.GetComponent<Button>().interactable = true ;
+        }
+        if (prevSylvieC - 1 >= 0 && constellationArr[prevSylvieR, prevSylvieC - 1] != null) {
+            constellationArr[prevSylvieR,prevSylvieC - 1].gameObject.GetComponent<Button>().interactable = true;
+        }
+        if (prevSylvieR + 1 < 7 && constellationArr[prevSylvieR + 1, prevSylvieC] != null) {
+        constellationArr[prevSylvieR + 1,prevSylvieC].gameObject.GetComponent<Button>().interactable = true;
+        }
+        if (prevSylvieR - 1 >= 0 && constellationArr[prevSylvieR - 1, prevSylvieC] != null) {
+           constellationArr[prevSylvieR - 1,prevSylvieC].gameObject.GetComponent<Button>().interactable = true ;
+        }
+        //disable old adjacent buttons
+        if (curSylvieC + 1 < 7 && constellationArr[curSylvieR, curSylvieC + 1] != null) {
+            constellationArr[curSylvieR, curSylvieC + 1].gameObject.GetComponent<Button>().interactable = false ;
+        }
+        if (curSylvieC - 1 >= 0 && constellationArr[curSylvieR, curSylvieC - 1] != null) {
+            constellationArr[curSylvieR,curSylvieC - 1].gameObject.GetComponent<Button>().interactable = false ;
+        }
+        if (curSylvieR + 1 < 7 && constellationArr[curSylvieR  + 1, curSylvieC] != null) {
+            constellationArr[curSylvieR + 1,curSylvieC].gameObject.GetComponent<Button>().interactable = false ;
+        }
+        if (curSylvieR - 1 >= 0 && constellationArr[curSylvieR - 1, curSylvieC] != null) {
+            constellationArr[curSylvieR - 1,curSylvieC].gameObject.GetComponent<Button>().interactable = false ;
+        }
+        //update the saved position
+        curSylvieR = prevSylvieR;
+        curSylvieC = prevSylvieC;
+        prevSylvieR = -1;
+        prevSylvieC = -1;
+        sylviePos.position = new Vector3(constellationArr[curSylvieR,curSylvieC].position.x, constellationArr[curSylvieR,curSylvieC].position.y,0);
+
+        //update Pollus' position
+        if (prevPollusR < 7 && prevPollusR >= 0 && prevPollusC < 7 && prevPollusC >= 0 && constellationArr[prevPollusR,prevPollusC] != null) {
+            pollusPos.position = new Vector3(constellationArr[prevPollusR,prevPollusC].position.x, constellationArr[prevPollusR,prevPollusC].position.y,0) ;
+            
+            curPollusR = prevPollusR;
+            curPollusC = prevPollusC;
+            prevPollusR = -1;
+            prevPollusC = -1;
+        }
+
+        //update Castor's position
+        if (prevCastorR < 7 && prevCastorR >= 0 && prevCastorC < 7 && prevCastorC >= 0 && constellationArr[prevCastorR, prevCastorC] != null) {
+            castorPos.position = new Vector3(constellationArr[prevCastorR,prevCastorC].position.x, constellationArr[prevCastorR,prevCastorC].position.y,0) ;
+            
+            curCastorR = prevCastorR;
+            curCastorC = prevCastorC;
+            prevCastorR = -1;
+            prevCastorC = -1;
+        }
+        
+        
+    }
     void Update()
     {
         if (curCastorR == targetPositionr1 && curCastorC == targetPositionc1) {

--- a/Assets/Scripts/Level Control Systems/SyvliePosFix.cs
+++ b/Assets/Scripts/Level Control Systems/SyvliePosFix.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SyvliePosFix : MonoBehaviour
+{
+    [SerializeField] private GameObject startingPos;
+    [SerializeField] private GameObject syvlie;
+    // Start is called before the first frame update
+    void Start()
+    {
+        syvlie.transform.position = startingPos.transform.position;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Level Control Systems/SyvliePosFix.cs.meta
+++ b/Assets/Scripts/Level Control Systems/SyvliePosFix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ea6fb3fdb38285488e89cd539063c62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created a new script that initializing Sylvie's starting position, regardless of where she was before (hopefully it works this time).

Note: new empty child game object under starting star is used to initialize Sylvie's position. For some reason I couldn't do this in the existing script. Feel free to make this more efficient as needed.