### PR TITLE
Switch Puzzle Complete to Header notif

### DIFF
--- a/Assets/Scripts/Managers/Notification/NotificationManager.cs
+++ b/Assets/Scripts/Managers/Notification/NotificationManager.cs
@@ -122,9 +122,8 @@ public class NotificationManager : Singleton<NotificationManager>
             {
                 AudioClip[] sounds = Instance.puzzleCompleteSounds;
                 return new Notification("Puzzle Complete!",
-                    Style.SIDEBAR,
-                    sounds[Random.Range(0, sounds.Length)],
-                    description: "You completed the puzzle.");
+                    Style.HEADER,
+                    sounds[Random.Range(0, sounds.Length)]);
             }
         }
 


### PR DESCRIPTION
Quick addition to #28 to remove the debug implementation of the Puzzle Complete notification as a sidebar graphic.